### PR TITLE
Use response body contents as raw data source.

### DIFF
--- a/src/HttpBinding.php
+++ b/src/HttpBinding.php
@@ -67,6 +67,6 @@ class HttpBinding
      */
     public function response(ResponseInterface $response, $name, array &$outputHeaders = null)
     {
-        return $this->interpreter->response($response->getBody()->__toString(), $name, $outputHeaders);
+        return $this->interpreter->response($response->getBody()->getContents(), $name, $outputHeaders);
     }
 }


### PR DESCRIPTION
@meng-tian Here is a little update to make it work with response body content. `__toString` is returning an empty string right now...